### PR TITLE
Update __init__.py to fix "TypeError: unorderable types" in python3 sorting

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -764,7 +764,7 @@ class Tickline(StencilView):
     def _update_tolerances(self, *args):
         self.scale_tolerances = sorted(
                                [(tick.scale_factor * tick.min_space, tick) 
-                                for tick in self.ticks])
+                                for tick in self.ticks], , key=lambda x: x[0])
     
     def _update_effect_constants(self, *args):
         if not self.scroll_effect:

--- a/__init__.py
+++ b/__init__.py
@@ -764,7 +764,7 @@ class Tickline(StencilView):
     def _update_tolerances(self, *args):
         self.scale_tolerances = sorted(
                                [(tick.scale_factor * tick.min_space, tick) 
-                                for tick in self.ticks], , key=lambda x: x[0])
+                                for tick in self.ticks], key=lambda x: x[0])
     
     def _update_effect_constants(self, *args):
         if not self.scroll_effect:


### PR DESCRIPTION
Fix to "TypeError: unorderable types" in python3 sorting:

   File "**init**.py", line 592, in on_ticks
     self._update_tolerances()
   File "__init__.py", line 767, in _update_tolerances
     for tick in self.ticks])
 TypeError: unorderable types: DataListTick() < Tick()
