### PR TITLE
TypeError: object.__init__() takes no parameters

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -611,7 +611,9 @@ class Tickline(StencilView):
         self.labeller = self.labeller_cls(self, **self.labeller_args)
         
     def on_scroll_effect_cls(self, *args):
-        effect = self.scroll_effect = self.scroll_effect_cls(round_value=False)
+        self.scroll_effect = self.scroll_effect_cls()
+        self.scroll_effect.round_value = False
+        effect = self.scroll_effect
         self._update_effect_constants()
         self._trigger_calibrate()
         effect.bind(scroll=self._update_from_scroll)


### PR DESCRIPTION
Workaround to fix this problem that only happen with python 3:
   File "/home/hdias/Work/Carva/mobile_apps/pre-release/portrait/pilothostel-portrait/libs/garden/garden.tickline/**init**.py", line 568, in **init**
     self.on_scroll_effect_cls()
   File "/home/hdias/Work/Carva/mobile_apps/pre-release/portrait/pilothostel-portrait/libs/garden/garden.tickline/**init**.py", line 614, in on_scroll_effect_cls
     effect = self.scroll_effect = self.scroll_effect_cls(round_value=False)
   File "/home/hdias/.local/lib/python3.5/site-packages/kivy/effects/kinetic.py", line 110, in **init**
     super(KineticEffect, self).**init**(**kwargs)
   File "kivy/_event.pyx", line 254, in kivy._event.EventDispatcher.__init__ (kivy/_event.c:5060)
 TypeError: object.__init__() takes no parameters
