### PR TITLE
Make tick_pos_index_iter work on Python3.7

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1109,15 +1109,14 @@ class Tick(Widget):
         tick_index, tick_pos, tick_sc = \
             self._get_index_n_pos_n_scale(tl, True)
         if tick_sc < self.min_space:
-            raise StopIteration
+            return
         condition = self._index_condition(tl, True)
         pos0 = tl.y if tl.is_vertical() else tl.x
         while condition(tick_index):
             yield tick_pos + pos0, tick_index
             tick_pos += tick_sc
-            tick_index += tl.dir    
-        raise StopIteration
-    
+            tick_index += tl.dir
+
     def display(self, tickline):
         '''main method for displaying Ticks. This is called after every
         scatter transform. Uses :attr:`draw` to handle actual drawing.


### PR DESCRIPTION
See https://stackoverflow.com/a/51701040 and PEP479. To quote the 3.7 changelog:
« PEP 479 is enabled for all code in Python 3.7, meaning that StopIteration exceptions raised directly or indirectly in coroutines and generators are transformed into RuntimeError exceptions. (Contributed by Yury Selivanov in bpo-32670.) »